### PR TITLE
add http protocol to url

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -95,7 +95,7 @@ app.use(serverError);
 
 app.set('port', config.PORT);
 app.listen(app.get('port'), config.IP, () => {
-    log.info(`WebService has started on ${config.IP}:${config.PORT} running in ${config.ENV.value} mode`);
+    log.info(`WebService has started on http://${config.IP}:${config.PORT} running in ${config.ENV.value} mode`);
 
     if (!config.ENV.prod) {
         log.info('PLEASE NOTE: your webservice is running not in a production mode!');


### PR DESCRIPTION
On startup it will log "WebService has started on http://localhost:3000" instead of "WebService has started on localhost:3000." This change allows the URL to be clickable in most terminals.